### PR TITLE
Update Serverless and Node version to use the latest LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM node:13-alpine
+FROM node:lts-alpine
+
+# SERVERLESS_VERSION is set explicitly in the Makefile used to build, otherwise use latest version.
+ARG SERVERLESS_VERSION=latest
+ENV SERVERLESS_VERSION $SERVERLESS_VERSION
+
 RUN apk --no-cache add python python3 python3-dev py-pip ca-certificates groff less bash make jq curl wget g++ zip git openssh postgresql-dev && \
     pip --no-cache-dir install awscli virtualenv && \
     update-ca-certificates
@@ -15,6 +20,6 @@ RUN ln -sf /opt/yarn/dist/bin/yarn /usr/local/bin/yarn && \
     ln -sf /opt/yarn/dist/bin/yarn /usr/local/bin/yarnpkg && \
     yarn --version
   
-ENV SERVERLESS serverless@2.11.1
-RUN yarn global add $SERVERLESS
+RUN yarn global add serverless@$SERVERLESS_VERSION
+
 WORKDIR /work


### PR DESCRIPTION
- Changes the container to use the serverless framework version via a parameter in build time.